### PR TITLE
Opt-out for CasaCore.jl

### DIFF
--- a/src/constants.jl
+++ b/src/constants.jl
@@ -44,6 +44,7 @@ const LICFILES=["LICENSE", "LICENSE.md", "License.md", "LICENSE.txt", "LICENSE.r
 # PYTHON = requires a Python package
 const PKGOPTS= ["ApproxFun"     =>  :BINARY,  # seems to need PyPlot, which we also exclude
                 "Arduino"       =>  :BINARY,
+                "CasaCore"      =>  :BINARY,
                 "Clang"         =>  :BINARY,
                 "CommonCrawl"   =>  :BINARY,  # needs AWS auth, downloads a lot
                 "CoreNLP"       =>  :PYTHON,


### PR DESCRIPTION
This package is a wrapper for a huge binary dependency (CasaCore).