### PR TITLE
Use the Conda Package as Python environment.

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -75,13 +75,8 @@ echo debconf shared/accepted-oracle-license-v1-1 seen true | sudo debconf-set-se
 sudo apt-get -y install oracle-java7-installer
 export JAVA_HOME=/usr/lib/jvm/java-7-oracle
 echo "export JAVA_HOME=/usr/lib/jvm/java-7-oracle" >> /home/vagrant/.profile
-# Install matplotlib for PyPlot.jl
-sudo apt-get install python-matplotlib
-# Install xlrd for ExcelReaders.jl
-sudo apt-get install python-pip
-sudo pip install xlrd
-# Install SymPy
-sudo pip install sympy
+# Use the Conda Package as Python environment
+export PYTHON = ""
 # need /usr/share/dict/words for TextAnalysis.jl
 sudo apt-get install wamerican
 


### PR DESCRIPTION
It would be nice if PakageEvaluator use the Conda package as Python environment. This will allow all packages to resolve their Python dependencies without submitting PR's to PackageEvaluator to install dependencies. Further more this will motivate the package maintainers to incorporate automatic installation of the Python dependencies using the Conda package and hence all using the Conda package will have automatic installation of the dependencies.

It can be incorporated as: https://github.com/stevengj/PyPlot.jl/blob/78e5a12eee25b362258d4522509f56a774195486/src/PyPlot.jl#L219-L238 or in a build scripts as:
```
using PyCall
import Conda
PyCall.conda && Conda.add(dependency)
```
Packages that support automatic installation of python dependencies using Conda:
 - PyPlot
 - IJulia
 - SymPy
 - ExcelReaders

Edit:
It will increase the run time as the installation of the Miniconda environment provided by Conda.jl takes a minute see, https://travis-ci.org/JuliaLang/IJulia.jl.