### PR TITLE
Add MPL2 to LICENSES

### DIFF
--- a/src/constants.jl
+++ b/src/constants.jl
@@ -17,6 +17,9 @@ const LICENSES=[("MIT",[
                     r"mit expat license",
                     r"mit \"expat\" license",
                     r"permission is hereby granted, free of charge,"]),
+                ("MPL v2",[
+                    r"mpl version 2",
+                    r"mozilla public license version 2"]),
                 ("GPL v2",[
                     r"gpl version 2",
                     r"gpl ?v2",


### PR DESCRIPTION
Currently a bunch of packages are mislabelled as GPL v2 when they should be MPL v2, as the MPL license text mentions GPL. This adds MPL support above GPL to avoid that. 

A future option might be to count matches and pick the license with the highest counts?