### PR TITLE
Update setup.sh to install mpmath for SymPy.

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -82,6 +82,7 @@ sudo apt-get install python-pip
 sudo pip install xlrd
 # Install SymPy
 sudo pip install sympy
+sudo pip install mpmath
 # need /usr/share/dict/words for TextAnalysis.jl
 sudo apt-get install wamerican
 


### PR DESCRIPTION
PackageEvaluator need to have mpmath installed as SymPy depends on it, cc @jverzani.
This should fix the SymPy failure on 0.3 see: http://pkg.julialang.org/logs/SymPy_0.3.log.